### PR TITLE
update for 18.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ WEBMIN_FW_UDP_INCOMING = 137 138
 NONFREE = yes
 
 CREDIT_ANCHORTEXT = File Server Appliance
+COMMON_CONF += ftp
 
 include $(FAB_PATH)/common/mk/turnkey/fileserver.mk
 include $(FAB_PATH)/common/mk/turnkey.mk

--- a/overlay/var/www/cgi-bin/index.pl
+++ b/overlay/var/www/cgi-bin/index.pl
@@ -38,10 +38,6 @@ Content-Type: text/html; charset=utf-8
             <div id="cp">
                 <div class="fragment-content">
                     <div>
-                        <a href="https://$ENV{HTTP_HOST}:12320"><img
-                        src="images/shell.png"/>Web Shell</a>
-                    </div>
-                    <div>
                         <a href="https://$ENV{HTTP_HOST}:12321"><img
                         src="images/webmin.png"/>Webmin</a>
                     </div>
@@ -54,6 +50,7 @@ Content-Type: text/html; charset=utf-8
                         <a href="https://$ENV{HTTP_HOST}/"><img
                         src="images/filemanager.png"/>WebDAV CGI<br/>File Manager</a>
                     </div>
+                   <div></div>
                    <div></div>
 
                     <h2>Resources and references</h2>

--- a/plan/main
+++ b/plan/main
@@ -3,4 +3,4 @@
 #include <turnkey/samba-dav>
 #include <turnkey/compression>
 #include <turnkey/nfs>
-
+#include <turnkey/ftp>


### PR DESCRIPTION
adds ftp, removes webshell link from landing page

depends on https://github.com/turnkeylinux/common